### PR TITLE
Invert Page Titles 

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,8 +1,14 @@
 'use strict';
 
+/*Colors */ 
 let _color = "black";
 let _cardColor = "#121212";
 let _invert = "white";
+
+/* Intervals */ 
+const INVERT_TITLES_INTERV = 100;  
+
+/* Timeouts */ 
 const SHADOW_TIMEOUT = 100;
 const PAGE_LOAD_TIMEOUT = 250; 
 const SPINNER_TIMEOUT = 2500;
@@ -29,8 +35,32 @@ const invertCourseText = () => {
     }
 }
 
+const invertPageTitles = () => {
+    let _invertPageTitles = () => {
+        let invertElements = (className) => {
+            if(document.getElementsByClassName(className).length > 0)
+                document.getElementsByClassName(className)[0].style.color = _invert; 
+        }
+
+        if(document.URL.includes('content')){
+            invertElements('d2l-page-title');
+            invertElements('d2l-heading-1');
+        }
+    }
+
+    _invertPageTitles(); 
+
+    const listener = new MutationObserver((mutations) => {
+        _invertPageTitles(); 
+    });
+
+    listener.observe(document.querySelector('title'),
+        {attributes: true, childList: true, subtree: true});
+}   
+
 const invertNavIcons = () => {
-    for(let i = 0; i<=3; ++i) {
+    try {
+        for(let i = 0; i<=3; ++i) {
          document.getElementsByClassName('d2l-dropdown-opener')[i]
                     .shadowRoot["children"][1]
                     .children[0]
@@ -38,6 +68,10 @@ const invertNavIcons = () => {
                     .shadowRoot
                     .children[0]
                     .style.color = _invert;
+        }
+    } catch(err) {
+        console.log("Failed to invert nav icons");
+        console.error(err);
     }
 
     let profileNameWrapper = document.getElementsByClassName('d2l-navigation-s-personal-menu-wrapper');
@@ -114,6 +148,12 @@ const darken = () => {
     let headings = document.getElementsByClassName('d2l-heading vui-heading-4')
     for(let i = 0; i<headings.length; ++i)
         headings[i].style.color = _invert; 
+
+    if(document.getElementsByClassName('vui-heading-1').length > 0)
+        document.getElementsByClassName('vui-heading-1')[0].style.color = _invert; 
+
+    if(document.URL.includes('content'))
+        invertPageTitles(); 
 
     //Nav Icons
     setTimeout(invertNavIcons, SHADOW_TIMEOUT);


### PR DESCRIPTION
## Description

Invert titles on content pages, and other headings. 

- Content Page issue was interesting, because switching tabs doesn't reload js. Used a mutation observer listener on document.title to fire a callback instead. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --
#17 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried it out on Chrome

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

May have to eventually DRY code. 